### PR TITLE
Renamed misspelled CodeRetreat

### DIFF
--- a/_posts/2014-07-23-CoderRetreat-Evening.md
+++ b/_posts/2014-07-23-CoderRetreat-Evening.md
@@ -5,7 +5,7 @@ location: The Innovation Factory
 register: http://www.eventbrite.ca/e/hamilton-coderetreat-evening-tickets-10285896393
 ---
 
-Hamilton Coderetreat Evening provides developers the opportunity to take part in focused practice away from the pressures of 'getting things done'.  If you are interested in pair programming, software design fundamentals and learning from your peers in a positive and welcoming space then this event is for you.
+Hamilton CodeRetreat Evening provides developers the opportunity to take part in focused practice away from the pressures of 'getting things done'.  If you are interested in pair programming, software design fundamentals and learning from your peers in a positive and welcoming space then this event is for you.
  
 Over the course of the evening we will break into pairs and practice implementing Conway's Game of Life.  There will be three 45 minute sessions followed by a group discussion where we can reflect on our experiences as a group.
  


### PR DESCRIPTION
Fixed the misspelled title of the event