### PR TITLE
removed reference, removed BarCamp ref

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,7 @@ tagline: Hamilton, Ontario
     </div>
     <div class="row">
       <div class="col-sm-12">            
-        <p>CoderCamp Hamilton was born from the spirit of BarCamp, and has evolved into a monthly mini-conference. 
-           CoderCamp is for local software developers to learn tools, techniques, and technologies from 
+        <p>CoderCamp Hamilton is a monthly meetup and mini-conference for local software developers to learn tools, techniques, and technologies from 
            one another in a casual and friendly setting. <span class="hidden-xs">We meet to talk about 
            coding, software development, and technology to learn from each other and get better at 
            what we do in the process.</span></p>
@@ -30,9 +29,7 @@ tagline: Hamilton, Ontario
             <div class="col-md-6">
                 <h2><i class="fa fa-info-circle"></i> About CoderCamp Hamilton</h2>    
                 
-                <p>CoderCamp meets monthly in local pubs in Hamilton, Ontario. We are an offshoot of 
-                    <a href="http://www.softwarehamilton.com/">Software Hamilton</a>, an organization 
-                    dedicated to connecting Greater Hamilton's software and startup communities.</p>
+                <p>CoderCamp meets monthly in local pubs in Hamilton, Ontario.</p>
                 
                 <p>We have a projector and screen set up for people to give presentations. We try to 
                     have a few speakers lined up in advance to give the event structure, but there is 


### PR DESCRIPTION
With the recent objections over the use of the name, I thought it best if we dropped the reference.

Also dropped the reference to BarCamp, assuming that's just anothe thing.

CC @bpoetz @rprouse 