### PR TITLE
Show upcoming events in order

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ tagline: Hamilton, Ontario
             <div class="col-md-6">
                 <h2><i class="fa fa-calendar-check-o"></i> Upcoming Events</h2>
 
-                {% for post in site.posts limit:2 %}
+                {% for post in site.posts reversed limit:2 %}
                 <div class="row">
                     <div class="col-sm-9">
                         <h3 class="index-post"><a href="{{ post.url }}" title="More info on {{post.title}}"><i class="fa fa-code"></i> {{ post.title }}</a></h3>


### PR DESCRIPTION
Right now the events are showing as the newest one first, which is weird for upcoming events, where you'd expect the first one to be the next event, followed by the one after that.

If there isn't some diligence in creating new event posts, this might have the last event show up as the first one, followed by the next event, but I personally think that's better than someone seeing the first one, thinking that was the next one and then missing an event!



Also I'm a horrible open source citizen because I haven't actually run this code to verify the change, I'm doing this through the github online editor like the terrible person I am. I will try and remember to test this until I get home, but merge and push to prod at your own risk until then :P