### PR TITLE
Ensure Jekyll is the same version used by GitHub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem 'jekyll'
-gem 'github-pages'
+gem 'jekyll', '3.3.0'
+gem 'github-pages', '~> 104'
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?


### PR DESCRIPTION
Minor PR. GitHub is now using Jekyll 3.3.0, so I thought we should specify that exact version.

https://github.com/blog/2277-what-s-new-in-github-pages-with-jekyll-3-3

Fixes #31