### PR TITLE
Hide events that are in the past

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,3 @@ Matt Grande is going to come tell us more about the HSR Real Time Data Hackathon
 Bryan will also providing a brief update on the Coderetreat Evening being planned for July 23rd.
 ```
 
-## Displaying more than one event
-
-The front page of the site assumes that there is only one upcoming event. On occasions where there is more than one event, edit `index.html` and change the limit in the line;
-
-```
-{% for post in site.posts limit:1 %}
-```
-
-Once the events have passed, don't forget to change it back.
-

--- a/index.html
+++ b/index.html
@@ -52,11 +52,11 @@ tagline: Hamilton, Ontario
                 <p class="visible-xs"><a class="btn btn-info" href="mailto:codercamphamilton@gmail.com" role="button"><i class="fa fa-hand-paper-o"></i> Volunteer</a></p>
 
             </div>
-            <div class="col-md-6">
+            <div id="eventHolder" class="col-md-6" style="display:none">
                 <h2><i class="fa fa-calendar-check-o"></i> Upcoming Events</h2>
 
                 {% for post in site.posts reversed limit:2 %}
-                <div class="row">
+                <div class="row upcoming-events" data-date="{{ post.date }}">
                     <div class="col-sm-9">
                         <h3 class="index-post"><a href="{{ post.url }}" title="More info on {{post.title}}"><i class="fa fa-code"></i> {{ post.title }}</a></h3>
                         <p class="index-info"><i class="fa fa-calendar"></i> {{ post.date | date: "%b %-d, %Y" }}{% if post.time %}&nbsp;&nbsp; <i class="fa fa-clock-o"></i> {{ post.time }}{% endif %}<br />
@@ -77,3 +77,19 @@ tagline: Hamilton, Ontario
 
     </div>
 </div>
+
+
+<script type="text/javascript">
+    window.onload = function(){
+        var today = new Date();
+        today.setHours(0,0,0,0);//Only compare the days, ignoring time
+        $('.upcoming-events').each(function(_,event){
+            var eventDate = new Date($(event).data('date'));
+            eventDate.setHours(0,0,0,0);
+            if (eventDate < today){
+                $(event).hide();
+            }
+        });
+        $('#eventHolder').show();
+    };
+</script>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ tagline: Hamilton, Ontario
             <div id="eventHolder" class="col-md-6" style="display:none">
                 <h2><i class="fa fa-calendar-check-o"></i> Upcoming Events</h2>
 
-                {% for post in site.posts reversed limit:2 %}
+                {% for post in site.posts reversed limit:4 %}
                 <div class="row upcoming-events" data-date="{{ post.date }}">
                     <div class="col-sm-9">
                         <h3 class="index-post"><a href="{{ post.url }}" title="More info on {{post.title}}"><i class="fa fa-code"></i> {{ post.title }}</a></h3>
@@ -77,7 +77,7 @@ tagline: Hamilton, Ontario
                 <div class="col-md-6">
                     <h2><i class="fa fa-calendar-check-o"></i> Upcoming Events</h2>
 
-                    {% for post in site.posts reversed limit:2 %}
+                    {% for post in site.posts reversed limit:4 %}
                     <div class="row">
                         <div class="col-sm-9">
                             <h3 class="index-post"><a href="{{ post.url }}" title="More info on {{post.title}}"><i class="fa fa-code"></i> {{ post.title }}</a></h3>

--- a/index.html
+++ b/index.html
@@ -73,6 +73,29 @@ tagline: Hamilton, Ontario
                 </div>
                 {% endfor %}
             </div>
+            <noscript>
+                <div class="col-md-6">
+                    <h2><i class="fa fa-calendar-check-o"></i> Upcoming Events</h2>
+
+                    {% for post in site.posts reversed limit:2 %}
+                    <div class="row">
+                        <div class="col-sm-9">
+                            <h3 class="index-post"><a href="{{ post.url }}" title="More info on {{post.title}}"><i class="fa fa-code"></i> {{ post.title }}</a></h3>
+                            <p class="index-info"><i class="fa fa-calendar"></i> {{ post.date | date: "%b %-d, %Y" }}{% if post.time %}&nbsp;&nbsp; <i class="fa fa-clock-o"></i> {{ post.time }}{% endif %}<br />
+                            <i class="fa fa-map-marker"></i> {{ post.location }}</p>
+                        </div>
+                        {% if post.register %}
+                        <div class="col-sm-3 index-register text-right hidden-xs">
+                            <a class="btn btn-info" href="{{post.register}}" role="button"><i class="fa fa-sign-in"></i> Register</a>
+                        </div>
+                        <div class="col-sm-3 index-register visible-xs">
+                            <a class="btn btn-info" href="{{post.register}}" role="button"><i class="fa fa-sign-in"></i> Register</a>
+                        </div>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
+                </div>
+            </noscript>
         </div>
 
     </div>


### PR DESCRIPTION
Loads the events as initially hidden and on page load a script hides the events that are in the past (I compare based on days so that any that exists for today will show, even if the event has started). There's also a fallback noscript section which just shows all of them for those people that don't have javascript enabled.

I've also set the limit to 4 events (since they are hidden anyways) and removed the section in the readme about changing the number of events, which is no longer required