### PR TITLE
S17e02

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 1. Install Ruby 2.1 ([Linux](https://www.ruby-lang.org/en/documentation/installation/), [Mac](https://gorails.com/setup/osx/10.10-yosemite), [Windows](http://rubyinstaller.org/))
 2. If you are on Windows, install [DevKit](http://rubyinstaller.org/add-ons/devkit/)
-3. `gem install jekyll`
-4. `gem install bundler`
+3. `gem install bundler`
 
 ## Building the project
 
@@ -22,7 +21,7 @@ GitHub will do this automatically when you push, but this allows you to view the
 2. Add a new file to `_posts` in the form `yyyy-mm-dd-title-of-event.md` where the date is the date of the event and the title is as it should appear. Dashes will be converted to spaces.
 3. Copy the content from another event file and edit as appropriate.
 4. Test your changes locally, then commit and push to GitHub.
-5. GitHub will automatically compile the changes and the event will appear. 
+5. GitHub will automatically compile the changes and the event will appear.
 
 The following is an example of an event file in Markdown format.
 
@@ -34,12 +33,12 @@ location: The Pheasant Plucker @ 20 Augusta Street
 register: http://www.eventbrite.ca/e/codercamp-hamilton-22-tickets-12184300571
 ---
 
-AJ Bovaird will tell us a little bit about the new features coming in ASP.net vNext.  
+AJ Bovaird will tell us a little bit about the new features coming in ASP.net vNext.
 
 [Rob Prouse](http://www.alteridem.net) will demonstrate creating applications for [Android Wear](https://github.com/Codercamp/AndroidWear) by prototyping an application that lists the pubs closest to you, allows you to view their menus and order on your watch.
-  
+
 Matt Grande is going to come tell us more about the HSR Real Time Data Hackathon on July 26th.
-  
+
 Bryan will also providing a brief update on the Coderetreat Evening being planned for July 23rd.
 ```
 

--- a/_posts/2017-02-08-CoderCamp-S17E02.md
+++ b/_posts/2017-02-08-CoderCamp-S17E02.md
@@ -1,0 +1,12 @@
+---
+layout: event
+time: 6:30pm to 9:00pm
+location: Upstairs @ The Pheasant Plucker - 20 Augusta Street
+register: http://codercamp.eventbrite.ca/
+---
+
+Presentations compiling...
+
+We are still looking for presentators. Please
+[contact us](mailto:codercamphamilton@gmail.com) if you are interested in giving
+a talk.


### PR DESCRIPTION
We have the date and we can display more than one upcoming event, so getting the placeholder in place.

I also removed installing jekyll globally as a setup step because it isn't needed. It gets installed locally by the `bundle install`