### PR TITLE
Mailing List Signup and Slack Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CoderCamp Hamilton website
 
-[![Join the chat at https://gitter.im/Codercamp/codercamp.github.io](https://badges.gitter.im/Codercamp/codercamp.github.io.svg)](https://gitter.im/Codercamp/codercamp.github.io?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://codercampslackin.azurewebsites.net/](https://codercampslackin.azurewebsites.net/badge.svg)](https://codercampslackin.azurewebsites.net/)
 
 ## Installing Jekyll
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,11 +6,15 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-  <link rel="stylesheet" href="/css/main.css"">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="/css/main.css" type="text/css">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" type="text/css">
+  <link rel="stylesheet" href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" type="text/css">
   <link rel="alternate" type="application/rss+xml" title="{{ site.author.name }}" href="{{ site.rss_path }}"">
   <link rel="alternate" type="application/atom+xml" title="{{ site.author.name }}" href="{{ site.atom_path }}" />
   <link rel="shortcut icon" href="/favicon.ico" />
+  <style type="text/css">
+      
+  </style>
 
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
         </button>
         <a class="navbar-brand" href="/" title="{{ site.tagline }}">
-            <div class="grow">        
+            <div class="grow">
                 <p><i class="fa fa-code"></i> {{ site.title }}</p>
             </div>
         </a>
@@ -18,6 +18,7 @@
             <li><a href="/events.html"><i class="fa fa-calendar"></i> Past Events</a></li>
             <li><a href="/conduct.html"><i class="fa fa-users"></i> Code of Conduct</a></li>
             <li><a href="mailto:codercamphamilton@gmail.com" title="Email CoderCamp"><i class="fa fa-envelope-o"></i> Contact</a></li>
+            <li><a href="https://codercampslackin.azurewebsites.net/" title="Chat on Slack"><i class="fa fa-slack"></i><span class="hidden-sm"> Slack</span></a></li>
             <li><a href="https://twitter.com/{{ site.author.twitter }}" target="_blank" title="CoderCamp on Twitter"><i class="fa fa-twitter"></i><span class="hidden-sm"> Twitter</span></a></li>
             <li><a href="https://github.com/{{ site.author.github }}" target="_blank" title="CoderCamp on GitHub"><i class="fa fa-github"></i><span class="hidden-sm"> GitHub</span></a></li>
             <li><a href="{{ " /rss.xml " | prepend: site.baseurl }}" title="Subscribe via RSS"><i class="fa fa-rss"></i><span class="hidden-sm hidden-md hidden-lg"> Subscribe via RSS</span></a></li>

--- a/css/main.scss
+++ b/css/main.scss
@@ -4,7 +4,7 @@
 
 $unused: false; // So I can see the color below in VS Code
 
-// SASS Colors 
+// SASS Colors
 
 $color-primary-0: #5F000B;	// Main Primary color */
 $color-primary-1: #A01324;
@@ -49,11 +49,15 @@ body {
   min-width: 320px;
 }
 
+#mc_embed_signup {
+    margin-top: 50px;
+}
+
 .content {
   padding: 40px 15px;
 }
 
-.navbar {    
+.navbar {
   min-width: 320px;
 }
 
@@ -75,12 +79,12 @@ body {
 
 .index-info {
     color: #666;
-    margin: 10px 0 5px 5px;    
+    margin: 10px 0 5px 5px;
     font-size: 80%;
 }
 
 .index-register {
-    margin: 10px 0 5px 0;    
+    margin: 10px 0 5px 0;
 }
 
 //==============================
@@ -91,8 +95,8 @@ body {
 }
 
 .events-info {
-    font-size: 80%;   
-    color: #666; 
+    font-size: 80%;
+    color: #666;
 }
 
 //==============================

--- a/index.html
+++ b/index.html
@@ -45,11 +45,16 @@ tagline: Hamilton, Ontario
                 <a href="http://harrypotter.wikia.com/wiki/House-elf">House-Elves</a> including
                 <a href="http://www.twitter.com/AJBovaird">AJ Bovaird</a>, but CoderCamp depends on the
                 tech community in Hamilton for support and talks. If you are working on something cool or
-                have something you would like to talk about, we would love to
-                <a href="mailto:codercamphamilton@gmail.com">hear from you</a>.</p>
+                have something you would like to talk about, join our
+                <a href="https://codercampslackin.azurewebsites.net/">Slack channel</a> and tell us about it.</p>
 
-                <p class="text-right hidden-xs"><a class="btn btn-info" href="mailto:codercamphamilton@gmail.com" role="button"><i class="fa fa-hand-paper-o"></i> Volunteer</a></p>
-                <p class="visible-xs"><a class="btn btn-info" href="mailto:codercamphamilton@gmail.com" role="button"><i class="fa fa-hand-paper-o"></i> Volunteer</a></p>
+                <div class="row">
+                    <div class="col-sm-6"><script async defer src="https://codercampslackin.azurewebsites.net/slackin.js?"></script></div>
+                    <div class="col-sm-6">
+                        <p class="text-right hidden-xs"><a class="btn btn-info" href="mailto:codercamphamilton@gmail.com" role="button"><i class="fa fa-hand-paper-o"></i> Volunteer</a></p>
+                        <p class="visible-xs"><a class="btn btn-info" href="mailto:codercamphamilton@gmail.com" role="button"><i class="fa fa-hand-paper-o"></i> Volunteer</a></p>
+                    </div>
+                </div>
 
             </div>
             <div id="eventHolder" class="col-md-6" style="display:none">

--- a/index.html
+++ b/index.html
@@ -57,29 +57,31 @@ tagline: Hamilton, Ontario
                 </div>
 
             </div>
-            <div id="eventHolder" class="col-md-6" style="display:none">
-                <h2><i class="fa fa-calendar-check-o"></i> Upcoming Events</h2>
 
-                {% for post in site.posts reversed limit:4 %}
-                <div class="row upcoming-events" data-date="{{ post.date }}">
-                    <div class="col-sm-9">
-                        <h3 class="index-post"><a href="{{ post.url }}" title="More info on {{post.title}}"><i class="fa fa-code"></i> {{ post.title }}</a></h3>
-                        <p class="index-info"><i class="fa fa-calendar"></i> {{ post.date | date: "%b %-d, %Y" }}{% if post.time %}&nbsp;&nbsp; <i class="fa fa-clock-o"></i> {{ post.time }}{% endif %}<br />
-                        <i class="fa fa-map-marker"></i> {{ post.location }}</p>
+            <div class="col-md-6">
+                <div id="eventHolder" style="display:none">
+                    <h2><i class="fa fa-calendar-check-o"></i> Upcoming Events</h2>
+
+                    {% for post in site.posts reversed limit:4 %}
+                    <div class="row upcoming-events" data-date="{{ post.date }}">
+                        <div class="col-sm-9">
+                            <h3 class="index-post"><a href="{{ post.url }}" title="More info on {{post.title}}"><i class="fa fa-code"></i> {{ post.title }}</a></h3>
+                            <p class="index-info"><i class="fa fa-calendar"></i> {{ post.date | date: "%b %-d, %Y" }}{% if post.time %}&nbsp;&nbsp; <i class="fa fa-clock-o"></i> {{ post.time }}{% endif %}<br />
+                            <i class="fa fa-map-marker"></i> {{ post.location }}</p>
+                        </div>
+                        {% if post.register %}
+                        <div class="col-sm-3 index-register text-right hidden-xs">
+                            <a class="btn btn-info" href="{{post.register}}" role="button"><i class="fa fa-sign-in"></i> Register</a>
+                        </div>
+                        <div class="col-sm-3 index-register visible-xs">
+                            <a class="btn btn-info" href="{{post.register}}" role="button"><i class="fa fa-sign-in"></i> Register</a>
+                        </div>
+                        {% endif %}
                     </div>
-                    {% if post.register %}
-                    <div class="col-sm-3 index-register text-right hidden-xs">
-                        <a class="btn btn-info" href="{{post.register}}" role="button"><i class="fa fa-sign-in"></i> Register</a>
-                    </div>
-                    <div class="col-sm-3 index-register visible-xs">
-                        <a class="btn btn-info" href="{{post.register}}" role="button"><i class="fa fa-sign-in"></i> Register</a>
-                    </div>
-                    {% endif %}
+                    {% endfor %}
                 </div>
-                {% endfor %}
-            </div>
-            <noscript>
-                <div class="col-md-6">
+
+                <noscript>
                     <h2><i class="fa fa-calendar-check-o"></i> Upcoming Events</h2>
 
                     {% for post in site.posts reversed limit:4 %}
@@ -99,8 +101,40 @@ tagline: Hamilton, Ontario
                         {% endif %}
                     </div>
                     {% endfor %}
+                </noscript>
+
+
+                <!-- Begin MailChimp Signup Form -->
+                <div id="mc_embed_signup">
+                    <h2><i class="fa fa-envelope-o"></i> Join the Mailing List</h2>
+
+                    <form action="//codercamphamilton.us13.list-manage.com/subscribe/post?u=c267a7596ad080511c5bdcd5e&amp;id=99c1648a30" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+
+                        <div class="form-group form-group-sm">
+                            <input type="email" value="" name="EMAIL" class="required email form-control" id="mce-EMAIL" placeholder="Email Address">
+                        </div>
+                        <div class="form-group form-group-sm">
+                            <input type="text" value="" name="FNAME" class="form-control" id="mce-FNAME" placeholder="First Name">
+                        </div>
+                        <div class="form-group form-group-sm">
+                            <input type="text" value="" name="LNAME" class="form-control" id="mce-LNAME" placeholder="Last Name">
+                        </div>
+
+                        <div id="mce-responses" class="clear">
+                            <div class="response" id="mce-error-response" style="display:none"></div>
+                            <div class="response" id="mce-success-response" style="display:none"></div>
+                        </div>
+
+                        <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+                        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_c267a7596ad080511c5bdcd5e_99c1648a30" tabindex="-1" value=""></div>
+                        <div class="text-right">
+                            <button class="btn btn-info" type="submit" name="subscribe"><i class="fa fa-hand-o-right"></i> Subscribe</button>
+                        </div>
+                    </form>
                 </div>
-            </noscript>
+
+                <!--End mc_embed_signup-->
+            </div>
         </div>
 
     </div>


### PR DESCRIPTION
Fixes #54

Adds a link to the slack channel in the header, a slack signup form/button and switches the readme badge from gitter to slack.

![image](https://cloud.githubusercontent.com/assets/493828/21906252/8b0b601a-d8d8-11e6-80b8-07d22c64744a.png)

![image](https://cloud.githubusercontent.com/assets/493828/21906242/83c30a10-d8d8-11e6-921a-c0fd099f1354.png)

Fixes #46 

Adds a Mailchimp signup to the front page.

![image](https://cloud.githubusercontent.com/assets/493828/21906286/adfe911e-d8d8-11e6-8880-a521c7be9007.png)
