### PR TITLE
Faster event loading

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,6 @@
 <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script async src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="/js/bootstrap.min.js"></script>
+<script async src="/js/bootstrap.min.js"></script>
 
 {% include google_analytics.html %}

--- a/index.html
+++ b/index.html
@@ -142,14 +142,18 @@ tagline: Hamilton, Ontario
 
 
 <script type="text/javascript">
-    window.onload = function(){
-        var today = new Date().toISOString().slice(0,10);//Only compare the days, ignoring time
-        $('.upcoming-events').each(function(_,event){
-            var eventDate = $(event).data('date').slice(0,10);
-            if (eventDate < today){
-                $(event).hide();
+    function displayCurrentEvents() {
+        var today = new Date().toISOString().slice(0,10),//Only compare the days, ignoring time
+            events = document.querySelectorAll('.upcoming-events'),
+            eventList = document.querySelector('#eventHolder');
+        
+        events.forEach(function(event) {
+            var eventDate = event.dataset.date.slice(0,10);
+            if (eventDate < today) {
+                event.style.display = 'none';
             }
         });
-        $('#eventHolder').show();
-    };
+        eventList.style.display = 'block';
+    }
+    displayCurrentEvents();
 </script>


### PR DESCRIPTION
Previously, because of the jQuery dependency, there was a bit of a delay with the event list from firing as brought up by @madmurdock. 

I've removed the jQuery dependency and redone the same script in pure JS, so it fires right away without having to wait for any external scripts to fire. Should speed things up.

Also, I threw the async attribute in when loading JS files - shouldn't matter too much, since they're loading in the footer, but won't hurt.