### PR TITLE
Add Docker support for development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+FROM ruby:2.6.3-buster
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The ruby image comes with a base non-root 'ruby' user which this Dockerfile
+# gives sudo access. Hoewver, for Linux, this user's GID/UID must match your local
+# user UID/GID to avoid permission issues with bind mounts. Update USER_UID / USER_GID
+# if yours is not 1000. See https://aka.ms/vscode-remote/containers/non-root-user.
+ARG USERNAME=ruby
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git and needed tools are installed
+    && apt-get install -y git procps \
+    && apt-get update \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for non-root users
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=
+
+ENV HOME /home/$USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update \
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
-
     #
     # Clean up
     && apt-get autoremove -y \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,6 @@
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"
 	},
-	"postCreateCommand": [ ],
 	// Comment out the next line to run as root instead. Linux users, update
 	// Dockerfile with your user's UID/GID if not 1000.
 	"runArgs": [ "-u", "ruby" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+	"name": "CoderCamp Hamilton",
+	"dockerFile": "Dockerfile",
+	"appPort": 4000,
+	"extensions": [
+		"rebornix.Ruby",
+		"castwide.solargraph"
+	],
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+	"postCreateCommand": [ ],
+	// Comment out the next line to run as root instead. Linux users, update
+	// Dockerfile with your user's UID/GID if not 1000.
+	"runArgs": [ "-u", "ruby" ]
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/README.md
+++ b/README.md
@@ -2,11 +2,57 @@
 
 [![Join the chat at https://codercampslackin.azurewebsites.net/](https://codercampslackin.azurewebsites.net/badge.svg)](https://codercampslackin.azurewebsites.net/)
 
-## Installing Jekyll
+To get started developing, you have two options. You can develop in a Docker Container using VS Code, or you can install Ruby locally and develop locally.
+
+## Installing Ruby and Jekyll
+
+Do the following if you want to develop using Ruby on your local machine.
 
 1. Install Ruby 2.1 ([Linux](https://www.ruby-lang.org/en/documentation/installation/), [Mac](https://gorails.com/setup/osx/10.10-yosemite), [Windows](http://rubyinstaller.org/))
 2. If you are on Windows, install [DevKit](http://rubyinstaller.org/add-ons/devkit/)
 3. `gem install bundler`
+
+## Installing Docker and VS Code
+
+Do this if you want to develop in a Docker container using VS Code.
+
+1. Install and configure [Docker](https://www.docker.com/get-started) for your operating system.
+
+    **Windows / macOS**:
+
+    1. Install [Docker Desktop for Windows/Mac](https://www.docker.com/products/docker-desktop).
+    2. Right-click on the Docker taskbar item and update **Settings / Preferences > Shared Drives / File Sharing** with the drive the web app source code is located in. If you run into trouble, see [Docker Desktop for Windows tips](/docs/remote/troubleshooting.md#docker-desktop-for-windows-tips) on avoiding common problems with sharing.
+
+    **Linux**:
+
+    1. Follow the [official install instructions for Docker CE/EE for your distribution](https://docs.docker.com/install/#supported-platforms).
+    2. Add your user to the `docker` group by using a terminal to run: `sudo usermod -aG docker $USER`
+    3. Sign out and back in again so your changes take effect.
+
+2. Install [Visual Studio Code](https://code.visualstudio.com/).
+3. Install the [Remote Development extension pack](https://aka.ms/vscode-remote/download/extension).
+
+### Quick Start for Docker with VSCode
+
+1. Start VS Code and click on the quick actions Status Bar item in the lower left corner of the window.
+
+    ![Quick actions status bar item](https://code.visualstudio.com/assets/docs/remote/common/remote-dev-status-bar.png)
+
+2. Select **Remote-Containers: Open Folder in Container...** from the command list that appears, and open the root folder of the project you just cloned.
+
+3. The window will then reload, but since the container does not exist yet, VS Code will create one. This may take some time, and a progress notification will provide status updates. Fortunately, this step isn't necessary the next time you open the folder since the container will already exist.
+
+    ![Dev Container Progress Notification](https://code.visualstudio.com/assets/docs/remote/containers/dev-container-progress.png)
+
+4. After the container is built, VS Code automatically connects to it and maps the project folder from your local file system into the container.
+
+5. Open the terminal in VS Code to a bash prompt within the container by clicking on **Terminal > New Terminal**
+
+6. In the terminal, type `bundle install` then `bundle exec jekyll serve` to build and run the web site. (See below)
+
+7. Open the web site at [http://localhost:4000](http://localhost:4000).
+
+8. Begin developing in Visual Studio Code.
 
 ## Building the project
 

--- a/_config.yml
+++ b/_config.yml
@@ -24,3 +24,4 @@ author :
 production_url: http://www.codercamphamilton.com
 rss_path: /rss.xml
 atom_path: /atom.xml
+host: 0.0.0.0


### PR DESCRIPTION
Developing the web site is difficult on Windows. You need to get the right version of Ruby installed, build tools, manage to get all of the correct Gems installed and built. It is much nicer to develop and run in Linux. This uses the new [Visual Studio Code Remote Development](https://code.visualstudio.com/docs/remote/containers) extension to allow you to develop using Visual Studio Code on Windows, Mac or Linux, but build and run the web app in a Linux Docker container.

For more information, see my changes to the Readme.md file. A quick overview;

1. Install Docker
2. Install Visual Studio Code
3. Install the Remote Development extension in VSCode

Then,

1. Open VS Code
2. Click the >< symbol in the lower left of the screen
3. Open folder in container

This will create and run a Docker container. The first time will take a few minutes. Next time you run it will come up in seconds. From here, the code will be mounted in the Docker container and opened in VS Code for your editing. From here you start developing;

1. Open a bash terminal in VS Code with Terminal | New Terminal
2. This is a bash terminal in your Docker container. How cool is that? 🤓
3. In the terminal, type `bundle install` then `bundle exec Jekyll serve` to build and run the web site. 
4. Open the web site at [http://localhost:4000](http://localhost:4000).

For those that don't want to use VS Code or continue to develop locally, there is no change. If you want to use the Docker container without VS Code, that works too, just run the image and mount the source folder into the image.