### PR TITLE
Remove the need to run bundle install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"
 	},
+	"postCreateCommand": "bundle install",
 	// Comment out the next line to run as root instead. Linux users, update
 	// Dockerfile with your user's UID/GID if not 1000.
 	"runArgs": [ "-u", "ruby" ]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Do this if you want to develop in a Docker container using VS Code.
 
 5. Open the terminal in VS Code to a bash prompt within the container by clicking on **Terminal > New Terminal**
 
-6. In the terminal, type `bundle install` then `bundle exec jekyll serve` to build and run the web site. (See below)
+6. In the terminal, type `bundle exec jekyll serve` to build and run the web site. (See below)
 
 7. Open the web site at [http://localhost:4000](http://localhost:4000).
 


### PR DESCRIPTION
This removes the need to do a `bundle install` after creating the container. It is now done automatically.