### PR TITLE
Add next week's CoderDrinks along with the last two for the record

### DIFF
--- a/_posts/2022-04-14-CoderCamp-S22E04.md
+++ b/_posts/2022-04-14-CoderCamp-S22E04.md
@@ -1,0 +1,12 @@
+---
+layout: event
+time: 7:00pm to 9:00pm
+location: Mosaic, 431 Barton St E · Hamilton, ON
+register: N/A
+---
+
+CoderCamp Hamilton is a monthly meetup / mini-conference for local software developers to learn tools, techniques, and technologies from one another in a casual and friendly setting. We meet to talk about coding, software development, and technology to learn from each other and get better at what we do in the process.
+
+We are kicking off CoderCamp again with informal mini-CoderDrinks 🍺 at Mosaic on Barton in Hamilton. There will be no presentations, just a get together of like-minded developers, techies, and friends. We'll return to presentations in the fall.
+
+We are looking for speakers or lightning talks. If you would like to talk, get in touch with Bryan Poetz ([@bpoetz](https://twitter.com/bpoetz)) or Rob Prouse ([@rprouse](https://twitter.com/rprouse)).

--- a/_posts/2022-06-16-CoderCamp-S22E06.md
+++ b/_posts/2022-06-16-CoderCamp-S22E06.md
@@ -1,0 +1,16 @@
+---
+layout: event
+time: 7:00pm to 9:00pm
+location: Mosaic, 431 Barton St E · Hamilton, ON
+register: N/A
+---
+
+CoderCamp Hamilton is a monthly meetup / mini-conference for local software developers to learn tools, techniques, and technologies from one another in a casual and friendly setting. We meet to talk about coding, software development, and technology to learn from each other and get better at what we do in the process.
+
+We are kicking off CoderCamp again with informal CoderDrinks 🍺 on the patio of Mosaic on Barton in Hamilton. There will be no presentations, just a get together of like-minded developers, techies, and friends. We'll return to presentations in the fall.
+
+## 🌎 COVID-19 safety measures
+
+We will meet outside on the patio, weather permitting, otherwise inside. We ask that if you are experiencing any Covid symptoms that you refrain from attending, we'll see you next time.
+
+We are looking for speakers or lightning talks. If you would like to talk, get in touch with Bryan Poetz ([@bpoetz](https://twitter.com/bpoetz)) or Rob Prouse ([@rprouse](https://twitter.com/rprouse)).

--- a/_posts/2022-07-14-CoderCamp-S22E07.md
+++ b/_posts/2022-07-14-CoderCamp-S22E07.md
@@ -1,0 +1,16 @@
+---
+layout: event
+time: 7:00pm to 9:00pm
+location: Mosaic, 431 Barton St E · Hamilton, ON
+register: https://www.meetup.com/codercamp-hamilton/events/286978867/
+---
+
+CoderCamp Hamilton is a monthly meetup / mini-conference for local software developers to learn tools, techniques, and technologies from one another in a casual and friendly setting. We meet to talk about coding, software development, and technology to learn from each other and get better at what we do in the process.
+
+We are kicking off CoderCamp again with informal CoderDrinks 🍺 on the patio of Mosaic on Barton in Hamilton. There will be no presentations, just a get together of like-minded developers, techies, and friends. We'll return to presentations in the fall.
+
+## 🌎 COVID-19 safety measures
+
+We will meet outside on the patio, weather permitting, otherwise inside. We ask that if you are experiencing any Covid symptoms that you refrain from attending, we'll see you next time.
+
+We are looking for speakers or lightning talks. If you would like to talk, get in touch with Bryan Poetz ([@bpoetz](https://twitter.com/bpoetz)) or Rob Prouse ([@rprouse](https://twitter.com/rprouse)).


### PR DESCRIPTION
Time to get back in the habit of publishing codercamp events.