### PR TITLE
defer scripts to preserve loading order

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,6 +1,6 @@
 <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-<script async src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script defer src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script async src="/js/bootstrap.min.js"></script>
+<script defer src="/js/bootstrap.min.js"></script>
 
 {% include google_analytics.html %}


### PR DESCRIPTION
Still async, but defer guarantees loading error where async does not. 